### PR TITLE
Feat #47 Tabs 컴포넌트 제작

### DIFF
--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -1,10 +1,6 @@
 import { styled } from 'styled-components';
 import { color, font } from '../../styles';
-import { useState } from 'react';
-
-interface ITabsProps {
-  tabLists: { name: string; callback?: () => void }[];
-}
+import { ITabsProps } from '../../types/tabsTypes';
 
 const TabsContainer = styled.div`
   display: flex;
@@ -32,23 +28,16 @@ const TabItem = styled.div<{ $isSelected?: boolean }>`
   `}
 `;
 
-const Tabs = ({ tabLists }: ITabsProps): JSX.Element => {
-  const [isSelected, setIsSelected] = useState<number>(0);
-
-  const onClickTab = (target: number): void => {
-    setIsSelected(target);
-  };
-
+const Tabs = ({ tabLists, currentTab }: ITabsProps): JSX.Element => {
   return (
     <TabsContainer>
       {tabLists?.slice(0, 10).map((item, index) => (
         <TabItem
           onClick={() => {
-            onClickTab(index);
-            if (item.callback) item.callback();
+            item.callback();
           }}
           key={index}
-          $isSelected={index === isSelected}>
+          $isSelected={currentTab === item.path}>
           {item.name}
         </TabItem>
       ))}

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -7,7 +7,7 @@ const TabsContainer = styled.div`
   width: 100%;
 `;
 
-const TabItem = styled.div<{ $isSelected?: boolean }>`
+const TabItem = styled.div<{ $isSelected: boolean }>`
   position: relative;
   width: 100%;
   display: flex;
@@ -33,9 +33,7 @@ const Tabs = ({ tabLists, currentTab }: ITabsProps): JSX.Element => {
     <TabsContainer>
       {tabLists?.slice(0, 10).map((item, index) => (
         <TabItem
-          onClick={() => {
-            item.callback();
-          }}
+          onClick={() => item.callback()}
           key={index}
           $isSelected={currentTab === item.path}>
           {item.name}

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -1,0 +1,59 @@
+import { styled } from 'styled-components';
+import { color, font } from '../../styles';
+import { useState } from 'react';
+
+interface ITabsProps {
+  tabLists: { name: string; callback?: () => void }[];
+}
+
+const TabsContainer = styled.div`
+  display: flex;
+  width: 100%;
+`;
+
+const TabItem = styled.div<{ $isSelected?: boolean }>`
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 8px 12px;
+  font-size: ${font.fontSize.fontSize14};
+  font-weight: ${font.fontWeight.fontWeight600};
+  cursor: pointer;
+  ${({ $isSelected }) =>
+    $isSelected
+      ? `
+        color: ${color.primary300};
+        border-bottom: 2px solid ${color.primary300};
+      `
+      : `
+        color: ${color.textGray400};
+        border-bottom: 1px solid ${color.textGray400};
+  `}
+`;
+
+const Tabs = ({ tabLists }: ITabsProps): JSX.Element => {
+  const [isSelected, setIsSelected] = useState<number>(0);
+
+  const onClickTab = (target: number): void => {
+    setIsSelected(target);
+  };
+
+  return (
+    <TabsContainer>
+      {tabLists?.slice(0, 10).map((item, index) => (
+        <TabItem
+          onClick={() => {
+            onClickTab(index);
+            if (item.callback) item.callback();
+          }}
+          key={index}
+          $isSelected={index === isSelected}>
+          {item.name}
+        </TabItem>
+      ))}
+    </TabsContainer>
+  );
+};
+
+export default Tabs;

--- a/src/types/tabsTypes.ts
+++ b/src/types/tabsTypes.ts
@@ -1,0 +1,4 @@
+export interface ITabsProps {
+  tabLists: { path: string; name: string; callback: () => void }[];
+  currentTab: string;
+}


### PR DESCRIPTION
## 요구사항
- Tab의 최대 갯수는 10개로 제한
- 한 번에 한 개의 탭만 select가능

## 메인 로직
- tabLists를 Props로 전달받아 각 Tab을 노출
- 최대 갯수 제한을 위해 slice함수 사용
- currentTab을 Props로 전달받아 tabLists 요소 중 path와 비교 후, 값을 TabItem 컴포넌트에 전달
- onClick함수를 통해 Props로 전달받은 callback 함수를 실행

## 사용방법
다음과 같은 형식으로 더미데이터 생성
`const dummyTabs = [{ path: 'path', name: '텍스트', callback: () => console.log('Hello') }]`

currentPath 저장
`const { pathname } = new URL(window.location.href);`

Tabs 컴포넌트 호출 후 Props로 전달
`<Tabs currentTab={pathname.slice(1)} tabLists={dummyTabs} />`