### PR TITLE
Feat #33 TextField 완성

### DIFF
--- a/src/components/textfield/TextField.tsx
+++ b/src/components/textfield/TextField.tsx
@@ -1,0 +1,109 @@
+import { styled } from 'styled-components';
+import {
+  ItextFieldProps,
+  ItextFieldStyleProps,
+} from '../../types/textfieldTypes';
+import { getTextFieldStyleOptions } from '../../util/textFieldUtils';
+import { textFieldStyles } from './textfield';
+import { useState } from 'react';
+import { font, color } from '../../styles';
+
+const TextFieldContainer = styled.input<{
+  $styleOptions: ItextFieldStyleProps;
+  $state: ItextFieldProps['state'];
+}>`
+  width: 364px;
+  height: 40px;
+  border-radius: 4px;
+  border: ${({ $styleOptions }) => $styleOptions.border};
+  background: ${({ $styleOptions }) => $styleOptions.background};
+  color: ${({ $styleOptions }) => $styleOptions.color};
+  font-size: ${font.fontSize.fontSize14};
+  font-weight: ${font.fontWeight.fontWeightRegular};
+  line-height: ${font.lineHeight.lineHeight144};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: stretch;
+  padding: 8px 16px;
+  &:focus {
+    border: ${textFieldStyles['focused'].border};
+    color: ${textFieldStyles['focused'].color};
+  }
+  &:disabled {
+    border: ${textFieldStyles['disable'].border};
+    color: ${textFieldStyles['disable'].color};
+  }
+`;
+
+const TextFieldLabel = styled.label`
+  font-size: ${font.fontSize.fontSize14};
+  font-weight: ${font.fontWeight.fontWeightRegular};
+  line-height: ${font.lineHeight.lineHeight144};
+`;
+
+const Message = styled.p`
+  font-size: ${font.fontSize.fontSize10};
+  font-weight: ${font.fontWeight.fontWeightRegular};
+  line-height: ${font.lineHeight.lineHeight128};
+  margin-top: 4px;
+  color: ${({ color }) => color};
+`;
+
+const TextField = ({
+  state,
+  id,
+  title,
+  isError,
+  customErrorMessage,
+  customSuccessMessage,
+  customInactiveMessage,
+  placeholder,
+  validate,
+  ...props
+}: ItextFieldProps): JSX.Element => {
+  const [isEmpty, setIsEmpty] = useState(true);
+  return (
+    <>
+      <TextFieldLabel htmlFor={id}>{title}</TextFieldLabel>
+      <TextFieldContainer
+        id={id}
+        $state={state}
+        $styleOptions={
+          isEmpty
+            ? getTextFieldStyleOptions('inactive')
+            : !validate
+            ? getTextFieldStyleOptions('activated')
+            : isError
+            ? getTextFieldStyleOptions('error')
+            : getTextFieldStyleOptions('positive')
+        }
+        placeholder={placeholder}
+        {...props}
+        value={props.value}
+        onChange={(e) => {
+          if (e.target.value !== '') setIsEmpty(false);
+          else setIsEmpty(true);
+          if (props.onChange) props.onChange(e);
+        }}></TextFieldContainer>
+
+      {validate ? (
+        isEmpty ? (
+          <Message color={color.textGray400}>
+            {customInactiveMessage || '인액티브메시지를 입력해주세요.'}
+          </Message>
+        ) : isError ? (
+          <Message color={color.systemError}>
+            {customErrorMessage || '에러메시지를 입력해주세요.'}
+          </Message>
+        ) : (
+          <Message color={color.systemPositive}>
+            {customSuccessMessage || '성공메시지를 입력해주세요.'}
+          </Message>
+        )
+      ) : null}
+    </>
+  );
+};
+
+export default TextField;

--- a/src/components/textfield/index.ts
+++ b/src/components/textfield/index.ts
@@ -1,0 +1,1 @@
+export { default as TextField } from './TextField.tsx';

--- a/src/components/textfield/textfield.ts
+++ b/src/components/textfield/textfield.ts
@@ -1,0 +1,29 @@
+import { color } from '../../styles';
+
+export const textFieldStyles = {
+  inactive: {
+    border: `1px solid ${color.borderLine300}`,
+    color: color.textTextHold,
+  },
+  focused: {
+    border: `1px solid ${color.primary500}`,
+    color: color.textGray900,
+  },
+  error: {
+    border: `1px solid ${color.systemError}`,
+    color: color.textGray900,
+  },
+  positive: {
+    border: `1px solid ${color.systemPositive}`,
+    color: color.textGray900,
+  },
+  activated: {
+    border: `1px solid ${color.borderLine300}`,
+    color: color.textGray900,
+  },
+  disable: {
+    border: `1px solid ${color.borderLine300}`,
+    color: color.textGray400,
+    background: color.background,
+  },
+};

--- a/src/types/textfieldTypes.ts
+++ b/src/types/textfieldTypes.ts
@@ -1,0 +1,23 @@
+export interface ItextFieldProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  state?:
+    | 'inactive'
+    | 'focused'
+    | 'error'
+    | 'positive'
+    | 'activated'
+    | 'disable';
+  id: string;
+  title: string;
+  validate: boolean;
+  isError?: boolean;
+  customErrorMessage?: string;
+  customSuccessMessage?: string;
+  customInactiveMessage?: string;
+}
+
+export interface ItextFieldStyleProps {
+  border: string;
+  color: string;
+  background?: string;
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -3,3 +3,4 @@ export * from './labelUtils';
 export * from './dialogUtils';
 export * from './navigationUtils';
 export * from './itemUtils';
+export * from './textFieldUtils';

--- a/src/util/textFieldUtils.ts
+++ b/src/util/textFieldUtils.ts
@@ -1,0 +1,11 @@
+import { textFieldStyles } from '../components/textfield/textfield';
+import { ItextFieldProps, ItextFieldStyleProps } from '../types/textfieldTypes';
+
+export const getTextFieldStyleOptions = (
+  state: ItextFieldProps['state'] = 'inactive',
+): ItextFieldStyleProps => {
+  const styleOptions = {
+    ...textFieldStyles[state],
+  };
+  return { ...styleOptions };
+};


### PR DESCRIPTION
- 유효성 검증이 필요할 때만 인액티브, 성공, 에러 메시지가 나타난다.
(멘토님께 여쭤본 결과 유효성 검증이 필요없을 때 인액티브 메시지가 나타나는 경우는 없다고 함.)
- 유효성 검증이 필요한 경우와 그렇지 않은 경우를 구분하기 위해 validate prop을 사용한다.
- 유효성 검증이 필요한 경우 validate에 true를 주고, onChange에 사용하고자 하는 유효성 함수를 입력한다.
- 검증 결과에 따라 보여지는 메세지의 내용과 색상, border 색상도 변경돼야 하므로 isError를 통해 상태를 관리한다.
- 유효성 검증이 필요하지 않은 경우에는 validate에 false를 준다. 그러면 메세지가 나타나지 않으며 border 색상도 inactive 또는 activated로만 변경된다.
- App.tsx에서의 TextField 컴포넌트 사용 예시
```
import PoinTStyleProvider from './styles/StyleProvider';
import { TextField } from './components/textfield';
import { useState } from 'react';

function App() {
  const [inputValue, setInputValue] = useState('');
  const [isError, setIsError] = useState(false);
  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
    setInputValue(e.target.value);
    if (e.target.value.length < 5) setIsError(true);
    else setIsError(false);
  };
  return (
    <PoinTStyleProvider>
      <>
        {/* 유효성 검사가 필요할 때의 TextField */}
        <TextField
          id='textfield'
          title='타이틀'
          placeholder={'값을 입력해주세요.'}
          onChange={onChangeInput}
          value={inputValue}
          validate={true}
          isError={isError}
          customErrorMessage='에러 메시지'
          customSuccessMessage='성공 메시지'
          customInactiveMessage='인액티브 메시지'></TextField>

        {/* 일반적인 TextField */}
        <TextField
          id='textfield'
          title='타이틀'
          placeholder={'값을 입력해주세요.'}
          validate={false}></TextField>

        {/* disabled TextField */}
        <TextField
          placeholder={'값을 입력해주세요.'}
          id='textfield'
          title='타이틀'
          validate={false}
          disabled></TextField>
      </>
    </PoinTStyleProvider>
  );
}

export default App;
```